### PR TITLE
[BUG] Fix the start_index and end_index to point to character indices, not token indices

### DIFF
--- a/src/chonkie/chunker/token.py
+++ b/src/chonkie/chunker/token.py
@@ -49,11 +49,13 @@ class TokenChunker(BaseChunker):
 
         # Encode full text
         text_tokens = self._encode(text)
+        decoded_text = self._decode(text_tokens)
         chunks = []
 
         # Calculate chunk positions
         start_indices = range(0, len(text_tokens), self.chunk_size - self.chunk_overlap)
 
+        current_char_pos = 0
         for start_idx in start_indices:
             # Get token indices for this chunk
             end_idx = min(start_idx + self.chunk_size, len(text_tokens))
@@ -62,11 +64,16 @@ class TokenChunker(BaseChunker):
             chunk_tokens = text_tokens[start_idx:end_idx]
             chunk_text = self._decode(chunk_tokens)
 
+            # Calculate character-based indices
+            chunk_start_char = decoded_text.find(chunk_text, current_char_pos)
+            chunk_end_char = chunk_start_char + len(chunk_text)
+            current_char_pos = chunk_end_char
+
             chunks.append(
                 Chunk(
                     text=chunk_text,
-                    start_index=start_idx,
-                    end_index=end_idx,
+                    start_index=chunk_start_char,
+                    end_index=chunk_end_char,
                     token_count=len(chunk_tokens),
                 )
             )


### PR DESCRIPTION
Several chonkers were returning incorrect indexes, either relating to the tokens or otherwise wrong. This was due to how the tokens were kept track of.

I'm not sure if the others I didn't modify are 100% correct, but they at least pass my simple tests

