### PR TITLE
Bump version to 0.2.0.post1 in pyproject.toml and __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "0.2.0"
+version = "0.2.0.post1"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense RAG chunking library"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -3,7 +3,7 @@ from .chunker import (BaseChunker, Chunk, SDPMChunker, SemanticChunk,
                       SentenceChunk, SentenceChunker, TokenChunker,
                       WordChunker)
 
-__version__ = "0.2.0"
+__version__ = "0.2.0.post1"
 __name__ = "chonkie"
 __author__ = "Bhavnick Minhas"
 


### PR DESCRIPTION
This pull request includes a version update for the `chonkie` project. The version has been incremented from `0.2.0` to `0.2.0.post1`.

Version update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7): Updated the project version to `0.2.0.post1`.
* [`src/chonkie/__init__.py`](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L6-R6): Updated the `__version__` attribute to `0.2.0.post1`.