### PR TITLE
[fix] Reorganize optional dependencies in pyproject.toml: rename 'sem…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,9 @@ Homepage = "https://github.com/bhavnicksm/chonkie"
 
 [project.optional-dependencies]
 model2vec = ["model2vec>=0.1.0", "numpy>=1.23.0"]
-semantic = ["sentence-transformers>=2.3.0", "numpy>=1.23.0"]
+st = ["sentence-transformers>=2.3.0", "numpy>=1.23.0"]
 openai = ["openai>=1.0.0", "numpy>=1.23.0"]
+semantic = ["model2vec>=0.1.0", "numpy>=1.23.0"]
 all = ["sentence-transformers>=2.3.0", "numpy>=1.23.0", "openai>=1.0.0", "model2vec>=0.1.0"]
 dev = ["pytest>=6.2.0", 
         "datasets>=1.14.0",


### PR DESCRIPTION
This pull request includes changes to the `pyproject.toml` file to update dependencies and reorganize the optional dependencies sections. The most important changes include renaming the `semantic` dependency group and adding a new `semantic` dependency group with different packages.

Changes to dependencies:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L41-R43): Renamed the `semantic` dependency group to `st`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L41-R43): Added a new `semantic` dependency group with `model2vec` and `numpy` packages.