### PR TITLE
[Refactor] Optimize similarity calculation by using np.divide for imp…

### DIFF
--- a/src/chonkie/embeddings/model2vec.py
+++ b/src/chonkie/embeddings/model2vec.py
@@ -67,7 +67,7 @@ class Model2VecEmbeddings(BaseEmbeddings):
 
     def similarity(self, u: "np.ndarray", v: "np.ndarray") -> float:
         """Compute cosine similarity of two embeddings."""
-        return float(np.dot(u, v) / (np.linalg.norm(u) * np.linalg.norm(v)))
+        return np.divide(np.dot(u, v), np.linalg.norm(u) * np.linalg.norm(v), dtype=float)
 
     def get_tokenizer_or_token_counter(self):
         return self.model.tokenizer

--- a/src/chonkie/embeddings/openai.py
+++ b/src/chonkie/embeddings/openai.py
@@ -140,8 +140,7 @@ class OpenAIEmbeddings(BaseEmbeddings):
 
     def similarity(self, u: np.ndarray, v: np.ndarray) -> float:
         """Compute cosine similarity between two embeddings."""
-        return float(np.dot(u, v) / (np.linalg.norm(u) * np.linalg.norm(v)))
-    
+        return np.divide(np.dot(u, v), np.linalg.norm(u) * np.linalg.norm(v), dtype=float)
     @property
     def dimension(self) -> int:
         """Return the embedding dimension."""


### PR DESCRIPTION
This pull request includes improvements to the computation of cosine similarity in the `similarity` method across two files to enhance numerical stability and precision.

Changes to cosine similarity computation:

* [`src/chonkie/embeddings/model2vec.py`](diffhunk://#diff-7567a68d2e120b898523d55da2af93d790a3030646dedf36d2914d9d2c5b2c31L70-R70): Modified the `similarity` method to use `np.divide` for computing the cosine similarity between two embeddings.
* [`src/chonkie/embeddings/openai.py`](diffhunk://#diff-1c6fe14879ec1f5807d2d569f4c80592b608d1fa67722bce3516116f617c8645L143-R143): Updated the `similarity` method to use `np.divide` for computing the cosine similarity between two embeddings.