### PR TITLE
[Refactor] Add min_chunk_size parameter to SemanticChunker and SentenceChunker

### DIFF
--- a/src/chonkie/chunker/sentence.py
+++ b/src/chonkie/chunker/sentence.py
@@ -65,7 +65,8 @@ class SentenceChunker(BaseChunker):
         tokenizer: Union[str, Any] = "gpt2",
         chunk_size: int = 512,
         chunk_overlap: int = 128,
-        min_sentences_per_chunk: int = 1
+        min_sentences_per_chunk: int = 1, 
+        min_chunk_size: int = 2
     ):
         """Initialize the SentenceChunker with configuration parameters.
 
@@ -88,10 +89,13 @@ class SentenceChunker(BaseChunker):
             raise ValueError("chunk_overlap must be less than chunk_size")
         if min_sentences_per_chunk < 1:
             raise ValueError("min_sentences_per_chunk must be at least 1")
+        if min_chunk_size < 1:
+            raise ValueError("min_chunk_size must be at least 1")
 
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
         self.min_sentences_per_chunk = min_sentences_per_chunk
+        self.min_chunk_size = min_chunk_size
     
     # TODO: This is a older method of sentence splitting that uses Regex
     # but since Regex in python via re is super slooooow we use a different method
@@ -175,8 +179,7 @@ class SentenceChunker(BaseChunker):
     def _split_sentences(self,
                         text: str,
                         delim: Union[str, List[str]]=['.', '!', '?', '\n'],
-                        sep: str="🦛", 
-                        min_length: int = 10) -> List[str]:
+                        sep: str="🦛") -> List[str]:
         """Fast sentence splitting while maintaining accuracy.
         
         This method is faster than using regex for sentence splitting and is more accurate than using the spaCy sentence tokenizer.
@@ -202,7 +205,7 @@ class SentenceChunker(BaseChunker):
         current = ""
         
         for s in splits:
-            if len(s.strip()) < min_length:
+            if len(s.strip()) < (self.min_chunk_size * 6):
                 current += s
             else:
                 if current:


### PR DESCRIPTION
This pull request includes changes to the `semantic.py` and `sentence.py` files in the `src/chonkie/chunker` directory. The changes primarily introduce a new `min_chunk_size` parameter and modify the sentence splitting logic to use this parameter.

### Changes related to `min_chunk_size` parameter:

* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L64-R65): Added `min_chunk_size` parameter to the `__init__` method and included a validation check to ensure it is at least 1. Updated the `_split_sentences` method to use `self.min_chunk_size * 5` instead of a fixed `min_length` value. [[1]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L64-R65) [[2]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L99-R108) [[3]](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L148-R151)
* [`src/chonkie/chunker/sentence.py`](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL68-R69): Added `min_chunk_size` parameter to the `__init__` method and included a validation check to ensure it is at least 1. Updated the `_split_sentences` method to use `self.min_chunk_size * 6` instead of a fixed `min_length` value. [[1]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL68-R69) [[2]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cR92-R98) [[3]](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL205-R208)

### Removal of `min_length` parameter:

* [`src/chonkie/chunker/semantic.py`](diffhunk://#diff-146b453f965159091625de58459bbbec8804c130d022226f0186b4439e1ba1d7L121-R125): Removed the `min_length` parameter from the `_split_sentences` method.
* [`src/chonkie/chunker/sentence.py`](diffhunk://#diff-f8621e6d7d2b3c3d8fecdaf6ec442aefbd9acecf06764aed2d6953b6e995ee7cL178-R182): Removed the `min_length` parameter from the `_split_sentences` method.