### PR TITLE
[Update] Bump version to 0.2.1.post1 and require Python 3.9 or higher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chonkie"
-version = "0.2.1"
+version = "0.2.1.post1"
 description = "🦛 CHONK your texts with Chonkie ✨ - The no-nonsense RAG chunking library"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 keywords = ["chunking", "rag", "nlp", "text-processing"]
 authors = [

--- a/src/chonkie/__init__.py
+++ b/src/chonkie/__init__.py
@@ -5,7 +5,7 @@ from .chunker import (BaseChunker, Chunk, SDPMChunker, SemanticChunk,
 from .embeddings import (BaseEmbeddings, SentenceTransformerEmbeddings, 
                          Model2VecEmbeddings, OpenAIEmbeddings, AutoEmbeddings)
 
-__version__ = "0.2.1"
+__version__ = "0.2.1.post1"
 __name__ = "chonkie"
 __author__ = "Bhavnick Minhas"
 


### PR DESCRIPTION
This pull request includes updates to the version and Python requirements for the `chonkie` project. The most important changes include updating the project version and the minimum required Python version.

Version updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R10): Updated the project version from `0.2.1` to `0.2.1.post1`.
* [`src/chonkie/__init__.py`](diffhunk://#diff-44a557df57b150a7b71a0b691e66e501f00f8983cc9c66dee9309aaf738bd408L8-R8): Updated the `__version__` attribute to `0.2.1.post1`.

Python requirements:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R10): Changed the `requires-python` field from `>=3.8` to `>=3.9`.