### PR TITLE
[Update] Change default embedding model in SemanticChunkers 

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -443,7 +443,7 @@ This version of `SemanticChunker` has some optimizations that speed it up consid
 from chonkie import SemanticChunker
 
 chunker = SemanticChunker(
-    embedding_model="all-minilm-l6-v2",
+    embedding_model="minishlab/potion-base-8M", # Default model supported with SemanticChunker
     chunk_size=512,
     similarity_threshold=0.7
 )
@@ -494,7 +494,7 @@ the `SDPMChunker` groups content via the semantic double-pass merging method, wh
 from chonkie import SDPMChunker
 
 chunker = SDPMChunker(
-    embedding_model="all-minilm-l6-v2",
+    embedding_model="minishlab/potion-base-8M",
     chunk_size=512,
     similarity_threshold=0.7,
     skip_window=1


### PR DESCRIPTION
This pull request includes changes to the `DOCS.md` file to update the default embedding model used in the examples for `SemanticChunker` and `SDPMChunker`.

Updates to embedding models:

* [`DOCS.md`](diffhunk://#diff-3f4fe07ebe4ba7ea65472755ddc67a72905bc98e55b5b84a2055c7e36b6f1054L446-R446): Changed the embedding model in the `SemanticChunker` example from `"all-minilm-l6-v2"` to `"minishlab/potion-base-8M"` to reflect the default model supported with `SemanticChunker`.
* [`DOCS.md`](diffhunk://#diff-3f4fe07ebe4ba7ea65472755ddc67a72905bc98e55b5b84a2055c7e36b6f1054L497-R497): Updated the embedding model in the `SDPMChunker` example from `"all-minilm-l6-v2"` to `"minishlab/potion-base-8M"`.