### PR TITLE
[Fix] Allow for functions as token_counters in BaseChunkers

### DIFF
--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -43,18 +43,6 @@ class BaseChunker(ABC):
             tokenizer_or_token_counter (Union[str, Any]): String, tokenizer object, or token counter object
 
         """
-        # if callable(tokenizer_or_token_counter):
-        #     self.tokenizer = None
-        #     self._tokenizer_backend = "callable"
-        #     self.token_counter = tokenizer_or_token_counter
-        # elif isinstance(tokenizer_or_token_counter, str):
-        #     self.tokenizer = self._load_tokenizer(tokenizer_or_token_counter)
-        #     self.token_counter = self._get_tokenizer_counter()
-        # else:
-        #     self.tokenizer = tokenizer_or_token_counter
-        #     self._tokenizer_backend = self._get_tokenizer_backend()
-        #     self.token_counter = self._get_tokenizer_counter()
-
         # First check if the tokenizer_or_token_counter is a string
         if isinstance(tokenizer_or_token_counter, str):
             self.tokenizer = self._load_tokenizer(tokenizer_or_token_counter)

--- a/src/chonkie/chunker/base.py
+++ b/src/chonkie/chunker/base.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from multiprocessing import Pool, cpu_count
 from typing import Any, Callable, List, Union
 
+import inspect
+
 
 @dataclass
 class Chunk:
@@ -41,13 +43,28 @@ class BaseChunker(ABC):
             tokenizer_or_token_counter (Union[str, Any]): String, tokenizer object, or token counter object
 
         """
-        if callable(tokenizer_or_token_counter):
+        # if callable(tokenizer_or_token_counter):
+        #     self.tokenizer = None
+        #     self._tokenizer_backend = "callable"
+        #     self.token_counter = tokenizer_or_token_counter
+        # elif isinstance(tokenizer_or_token_counter, str):
+        #     self.tokenizer = self._load_tokenizer(tokenizer_or_token_counter)
+        #     self.token_counter = self._get_tokenizer_counter()
+        # else:
+        #     self.tokenizer = tokenizer_or_token_counter
+        #     self._tokenizer_backend = self._get_tokenizer_backend()
+        #     self.token_counter = self._get_tokenizer_counter()
+
+        # First check if the tokenizer_or_token_counter is a string
+        if isinstance(tokenizer_or_token_counter, str):
+            self.tokenizer = self._load_tokenizer(tokenizer_or_token_counter)
+            self.token_counter = self._get_tokenizer_counter()
+        # Then check if the tokenizer_or_token_counter is a function via inspect
+        elif inspect.isfunction(tokenizer_or_token_counter):
             self.tokenizer = None
             self._tokenizer_backend = "callable"
             self.token_counter = tokenizer_or_token_counter
-        elif isinstance(tokenizer_or_token_counter, str):
-            self.tokenizer = self._load_tokenizer(tokenizer_or_token_counter)
-            self.token_counter = self._get_tokenizer_counter()
+        # If not function or string, then assume it's a tokenizer object
         else:
             self.tokenizer = tokenizer_or_token_counter
             self._tokenizer_backend = self._get_tokenizer_backend()
@@ -62,7 +79,7 @@ class BaseChunker(ABC):
         elif "tiktoken" in str(type(self.tokenizer)):
             return "tiktoken"
         else:
-            raise ValueError("Tokenizer backend not supported")
+            raise ValueError(f"Tokenizer backend {str(type(self.tokenizer))} not supported")
 
     def _load_tokenizer(self, tokenizer_name: str):
         """Load a tokenizer based on the backend."""
@@ -129,7 +146,7 @@ class BaseChunker(ABC):
         elif self._tokenizer_backend == "tiktoken":
             return self.tokenizer.encode(text)
         else:
-            raise ValueError("Tokenizer backend not supported.")
+            raise ValueError(f"Tokenizer backend {self._tokenizer_backend} not supported.")
 
     def _encode_batch(self, texts: List[str]):
         """Encode a batch of texts using the backend tokenizer."""
@@ -145,7 +162,7 @@ class BaseChunker(ABC):
         elif self._tokenizer_backend == "tiktoken":
             return self.tokenizer.encode_batch(texts)
         else:
-            raise ValueError("Tokenizer backend not supported.")
+            raise ValueError(f"Tokenizer backend {self._tokenizer_backend} not supported.")
 
     def _decode(self, tokens) -> str:
         """Decode tokens using the backend tokenizer."""
@@ -156,7 +173,7 @@ class BaseChunker(ABC):
         elif self._tokenizer_backend == "tiktoken":
             return self.tokenizer.decode(tokens)
         else:
-            raise ValueError("Tokenizer backend not supported.")
+            raise ValueError(f"Tokenizer backend {self._tokenizer_backend} not supported.")
 
     def _decode_batch(self, token_lists: List[List[int]]) -> List[str]:
         """Decode a batch of token lists using the backend tokenizer."""
@@ -167,7 +184,7 @@ class BaseChunker(ABC):
         elif self._tokenizer_backend == "tiktoken":
             return [self.tokenizer.decode(tokens) for tokens in token_lists]
         else:
-            raise ValueError("Tokenizer backend not supported.")
+            raise ValueError(f"Tokenizer backend {self._tokenizer_backend} not supported.")
 
     def _count_tokens(self, text: str) -> int:
         """Count tokens in text using the backend tokenizer."""


### PR DESCRIPTION
This pull request includes several changes to the `src/chonkie/chunker/base.py` file to improve the handling of different tokenizer backends and provide more informative error messages. The most important changes include adding the `inspect` module to check if an object is a function, updating the initialization logic to handle different types of tokenizers, and enhancing the error messages to include the unsupported tokenizer backend type.

Improvements to tokenizer handling:

* Added import of `inspect` module to check if an object is a function. (`src/chonkie/chunker/base.py`)
* Updated the `__init__` method to first check if the `tokenizer_or_token_counter` is a string, then check if it is a function using `inspect.isfunction`, and finally assume it is a tokenizer object if neither condition is met. (`src/chonkie/chunker/base.py`)

Enhanced error messages:

* Updated the `_get_tokenizer_backend` method to include the unsupported tokenizer backend type in the error message. (`src/chonkie/chunker/base.py`)
* Updated the `_encode`, `_encode_batch`, `_decode`, and `_decode_batch` methods to include the unsupported tokenizer backend type in the error messages. (`src/chonkie/chunker/base.py`) [[1]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L132-R137) [[2]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L148-R153) [[3]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L159-R164) [[4]](diffhunk://#diff-10846354259652bb75e491a4bbce39e3909b204c82e70145936f910655ad97a0L170-R175)